### PR TITLE
Option so that markers commandline option usage performs a deselect instead of a skip

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 0.9.0 - Tests are deselected by CLI options by default
+
+ - **Breaking change** the plugin now by default deselects all tests that were usually skipped by marker CLI config. 
+   New `--pilot-skip` flag option can be used to enable the legacy behaviour where tests where marked as skipped 
+   instead. Fixes [#20](https://github.com/smarie/python-pytest-pilot/issues/20)
+
 ### 0.8.0 - New `easymarkers` fixture
 
  - New `easymarkers` fixture to access current values of all CLI options related to EasyMarkers, from within tests. Fixed [#17](https://github.com/smarie/python-pytest-pilot/issues/17)

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,10 @@
 
 [![Documentation](https://img.shields.io/badge/doc-latest-blue.svg)](https://smarie.github.io/python-pytest-pilot/) [![PyPI](https://img.shields.io/pypi/v/pytest-pilot.svg)](https://pypi.python.org/pypi/pytest-pilot/) [![Downloads](https://pepy.tech/badge/pytest-pilot)](https://pepy.tech/project/pytest-pilot) [![Downloads per week](https://pepy.tech/badge/pytest-pilot/week)](https://pepy.tech/project/pytest-pilot) [![GitHub stars](https://img.shields.io/github/stars/smarie/python-pytest-pilot.svg)](https://github.com/smarie/python-pytest-pilot/stargazers)
 
+!!! success "Starting in `0.9.0`, tests are deselected instead of being skipped - leading to huge performance gains 
+on large test codebases. Legacy behaviour can be set back with `--pilot-skip`, see [below](#deselecting-or-skipping)."
+
+
 In `pytest` we can create custom markers and filter tests according to them using the `-m` flag, as explained [here](https://docs.pytest.org/en/latest/example/markers.html). However 
 
  - by default it only supports one kind of marker query behaviour: a test with a mark <M> will run *even* if you do not use the `-m <M>` flag. If you wish to implement something more complex, you have to add code in your `conftest.py` as explained [here](http://doc.pytest.org/en/latest/example/markers.html#marking-platform-specific-tests-with-pytest) 
@@ -107,10 +111,11 @@ def test_bar():
     pass
 ```
 
-Running `pytest` (with the `-rs` option to show a summary of skipped tests) yields:
+Running `pytest` (with the `-rs` option to show a summary of skipped tests, and with the new 
+[--pilot-skip](#deselecting-or-skipping) flag) yields:
 
 ```
->>> pytest -rs
+>>> pytest -rs --pilot-skip
 ============================= test session starts ==========================================
 (...)
 collected 4 items
@@ -129,7 +134,7 @@ SKIPPED [1] <file>: This test requires 'envid'='b'. Run `pytest --envid=b` to ac
 And we can instead activate environment `'b'`.
 
 ```
->>> pytest -rs --envid=b
+>>> pytest -rs --pilot-skip --envid=b
 ============================= test session starts ==========================================
 (...)
 collected 4 items
@@ -173,10 +178,11 @@ def test_bar():
     pass
 ```
 
-Running `pytest` (with the `-rs` option to show a summary of skipped tests) yields:
+Running `pytest` (with the `-rs` option to show a summary of skipped tests, and with the new 
+[--pilot-skip](#deselecting-or-skipping) flag) yields:
 
 ```
->>> pytest -rs
+>>> pytest -rs --pilot-skip
 ============================= test session starts ==========================================
 (...)
 collected 2 items
@@ -192,7 +198,7 @@ SKIPPED [1] <file>: This test requires 'slow'. Run `pytest --slow` to activate i
 And we can run all tests including the slow ones with `--slow`:
 
 ```
->>> pytest -rs --slow
+>>> pytest -rs --pilot-skip --slow
 ============================= test session starts ==========================================
 (...)
 collected 2 items
@@ -238,10 +244,11 @@ def test_bar():
     pass
 ```
 
-Running `pytest` (with the `-rs` option to show a summary of skipped tests) yields:
+Running `pytest` (with the `-rs` option to show a summary of skipped tests, and with the new 
+[--pilot-skip](#deselecting-or-skipping) flag) yields:
 
 ```
->>> pytest -rs
+>>> pytest -rs --pilot-skip
 ============================= test session starts ==========================================
 (...)
 collected 4 items                                                                                                                                                                                                   
@@ -256,7 +263,7 @@ pytest_pilot/test_doc/test_hardfilter.py::test_bar PASSED                [100%]
 We can instead filter on tests with the `'red'` flavour:
 
 ```
->>> pytest -rs --flavour=red
+>>> pytest -rs --pilot-skip --flavour=red
 ============================= test session starts ==========================================
 (...)
 collected 4 items
@@ -304,10 +311,11 @@ def test_foo():
     pass
 ```
 
-Running `pytest` (with the `-rs` option to show a summary of skipped tests) yields:
+Running `pytest` (with the `-rs` option to show a summary of skipped tests, and with the new 
+[--pilot-skip](#deselecting-or-skipping) flag) yields:
 
 ```
->>> pytest -rs
+>>> pytest -rs --pilot-skip
 ============================= test session starts ==========================================
 (...)
 collected 3 items                                                                                                                                                                                                   
@@ -321,7 +329,7 @@ pytest_pilot/test_doc/test_hardfilter.py::test_foo PASSED                [100%]
 We can instead filter on tests with the `'yellow'` flavour:
 
 ```
->>> pytest -rs --flavour=yellow
+>>> pytest -rs --pilot-skip --flavour=yellow
 ============================= test session starts ==========================================
 (...)
 collected 3 items
@@ -338,6 +346,15 @@ SKIPPED [1] <file>: This test requires 'flavour'='red'. Currently `--flavour=yel
 You can see that now `test_foo`, that was not marked, was not skipped - as opposed to the previous example of "hard filter".
 
 ### 7. Misc
+
+#### Deselecting or skipping
+
+By default starting in version `0.9.0`, tests that should not run because of a given combination of markers and 
+commandline options are simply deselected. This is much faster on large test codebases than marking tests as skipped.
+
+The legacy mode where tests that should not run appear as "skipped" can be enabled with the new `--pilot-skip` 
+commandline option as shown above.
+
 
 #### Knowing the value of the command options inside a test
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,11 @@ requires = [
     "six",
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    "error",
+    # note the use of single quote below to denote "raw" strings in TOML
+    'ignore:Passing unrecognized arguments to super\(PyDevIPCompleter6\):DeprecationWarning'
+    # 'ignore:function ham\(\) is deprecated:DeprecationWarning',
+]

--- a/pytest_pilot/tests/test_main.py
+++ b/pytest_pilot/tests/test_main.py
@@ -118,7 +118,8 @@ def test_basic_options_help(testdir):
     (('--envid=env1',), dict(passed=5, skipped=2)),
     (('--flavour=red', '--envid=env2'), dict(passed=4, skipped=3))
 ])
-def test_basic_run_queries(testdir, cmdoptions, results):
+@pytest.mark.parametrize("skip_opt", [False, True])
+def test_basic_run_queries(testdir, cmdoptions, results, skip_opt):
     """executes the test in ../test_cases/basic/ folder with option --silo"""
 
     # basicdir = testdir.mkdir('basic')
@@ -128,8 +129,15 @@ def test_basic_run_queries(testdir, cmdoptions, results):
     make_file(testdir, case_folder, '__init__.py')  # required for the "import from ." to work
 
     # 2) run
+    if skip_opt:
+        cmdoptions += ("--pilot-skip",)
     result = testdir.runpytest(testdir.tmpdir, '-v', '-s', *cmdoptions)
     # the only test skipped should be the one with env2
+
+    if not skip_opt:
+        # Tests are deselected by default, they do not appear as skipped
+        results = dict(results)  # create a copy otherwise this leaks on other tests
+        results["skipped"] = 0
     result.assert_outcomes(**results)
 
 

--- a/pytest_pilot/tests/test_main.py
+++ b/pytest_pilot/tests/test_main.py
@@ -1,4 +1,8 @@
-from distutils.version import LooseVersion
+try:
+    from packaging.version import parse as LooseVersion
+except ModuleNotFoundError:
+    from distutils.version import LooseVersion
+
 from os.path import dirname, join, pardir
 
 import pytest
@@ -86,7 +90,7 @@ def test_basic_options_help(testdir):
     # 2) assert
     result = testdir.runpytest(testdir.tmpdir, '--help')
 
-    if LooseVersion(pytest.__version__) < "5.0.0":
+    if LooseVersion(pytest.__version__) < LooseVersion("5.0.0"):
         # note: in old pytest the help is formatted a bit differently
         expected_lines = ["  -Z, --silo            only run tests marked as silo (marked with @silo)."]
     else:


### PR DESCRIPTION
Will fix #20 and its duplicate #14 